### PR TITLE
Added missing use PaymentMethodClient

### DIFF
--- a/src/ShopwareApi.php
+++ b/src/ShopwareApi.php
@@ -21,6 +21,7 @@ use Flooris\ShopwareApiIntegration\Clients\SalesChannelClient;
 use Flooris\ShopwareApiIntegration\Clients\ProductMediaClient;
 use Flooris\ShopwareApiIntegration\Clients\PropertyGroupClient;
 use Flooris\ShopwareApiIntegration\Clients\CalculatedTaxClient;
+use Flooris\ShopwareApiIntegration\Clients\PaymentMethodClient;
 use Flooris\ShopwareApiIntegration\Clients\ProductVisibilityClient;
 use Flooris\ShopwareApiIntegration\Clients\ProductFeaturesSetClient;
 use Flooris\ShopwareApiIntegration\Clients\PropertyGroupOptionClient;


### PR DESCRIPTION
The ShopwareApi class uses the PaymentMethodClient class in the paymentMethod() function, but this was not included in the uses of the class, which lead to an error message. This PR fixes that.